### PR TITLE
Refactor: Enhance script robustness and configuration consistency

### DIFF
--- a/hypr/conf/decorations.conf
+++ b/hypr/conf/decorations.conf
@@ -1,7 +1,13 @@
 decoration {
     rounding = 8
     blur {
-        enabled = true; size = 6; passes = 3; new_optimizations = true;
-        xray = true; noise = 0.015; contrast = 1.0; brightness = 0.95;
+        enabled = true
+        size = 6
+        passes = 3
+        new_optimizations = true
+        xray = true
+        noise = 0.015
+        contrast = 1.0
+        brightness = 0.95
     }
 }

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -1,12 +1,12 @@
 monitor=,preferred,auto,1
 
-source = ~/.config/hypr/conf/env.conf
-source = ~/.config/hypr/conf/execs.conf
-source = ~/.config/hypr/conf/general.conf
-source = ~/.config/hypr/conf/input_gestures.conf
-source = ~/.config/hypr/conf/layouts.conf
-source = ~/.config/hypr/conf/misc.conf
-source = ~/.config/hypr/conf/decorations.conf
-source = ~/.config/hypr/conf/animations.conf
-source = ~/.config/hypr/conf/keybinds.conf
-source = ~/.config/hypr/conf/windowrules.conf
+source = conf/env.conf
+source = conf/execs.conf
+source = conf/general.conf
+source = conf/input_gestures.conf
+source = conf/layouts.conf
+source = conf/misc.conf
+source = conf/decorations.conf
+source = conf/animations.conf
+source = conf/keybinds.conf
+source = conf/windowrules.conf

--- a/hypr/scripts/brightness_notify.sh
+++ b/hypr/scripts/brightness_notify.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 CRIMSON="#DC143C"
 LIGHT_GRAY="#cccccc"
 NEAR_BLACK="#0a0a0a"

--- a/hypr/scripts/idle_config.sh
+++ b/hypr/scripts/idle_config.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 hypridle \
     timeout 300 'hyprlock' \
     timeout 330 'hyprctl dispatch dpms off' \

--- a/hypr/scripts/rofi_powermenu.sh
+++ b/hypr/scripts/rofi_powermenu.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 shutdown="Shutdown"
 reboot="Reboot"
 lock="Lock Screen"

--- a/hypr/scripts/volume_notify.sh
+++ b/hypr/scripts/volume_notify.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 CRIMSON="#DC143C"
 LIGHT_GRAY="#cccccc"
 NEAR_BLACK="#0a0a0a"

--- a/scripts/config/alacritty.sh
+++ b/scripts/config/alacritty.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 TARGET_FILE="$ALACRITTY_TARGET_DIR/alacritty.toml"
 echo "Generating $TARGET_FILE..."
 mkdir -p "$(dirname "$TARGET_FILE")"

--- a/scripts/config/hyprland_animations.sh
+++ b/scripts/config/hyprland_animations.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/animations.conf"
 

--- a/scripts/config/hyprland_decorations.sh
+++ b/scripts/config/hyprland_decorations.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/decorations.conf"
 

--- a/scripts/config/hyprland_env.sh
+++ b/scripts/config/hyprland_env.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/env.conf"
 

--- a/scripts/config/hyprland_execs.sh
+++ b/scripts/config/hyprland_execs.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/execs.conf"
 

--- a/scripts/config/hyprland_general.sh
+++ b/scripts/config/hyprland_general.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/general.conf"
 

--- a/scripts/config/hyprland_input_gestures.sh
+++ b/scripts/config/hyprland_input_gestures.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/input_gestures.conf"
 

--- a/scripts/config/hyprland_keybinds.sh
+++ b/scripts/config/hyprland_keybinds.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/keybinds.conf"
 

--- a/scripts/config/hyprland_layouts.sh
+++ b/scripts/config/hyprland_layouts.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/layouts.conf"
 

--- a/scripts/config/hyprland_main.sh
+++ b/scripts/config/hyprland_main.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 HYPRLAND_CONF_MAIN_TARGET="$CONFIG_TARGET_DIR/hypr/hyprland.conf"
 

--- a/scripts/config/hyprland_misc.sh
+++ b/scripts/config/hyprland_misc.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_FILE="$HYPR_CONF_TARGET_DIR/misc.conf"
 

--- a/scripts/config/hyprland_scripts_content.sh
+++ b/scripts/config/hyprland_scripts_content.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 echo "Generating Hyprland helper scripts in $HYPR_SCRIPTS_TARGET_DIR..."
 mkdir -p "$HYPR_SCRIPTS_TARGET_DIR"
 cat << 'EOF' > "$HYPR_SCRIPTS_TARGET_DIR/idle_config.sh"

--- a/scripts/config/hyprpaper.sh
+++ b/scripts/config/hyprpaper.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 HYPRPAPER_CONF_FILE="$CONFIG_TARGET_DIR/hypr/hyprpaper.conf"
 DEFAULT_WALLPAPER_NAME="crimson_black_wallpaper.png"
 DEFAULT_WALLPAPER_PATH="$WALLPAPER_DIR_TARGET/$DEFAULT_WALLPAPER_NAME"

--- a/scripts/config/rofi_info.sh
+++ b/scripts/config/rofi_info.sh
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 echo "INFO: Rofi uses default theme. Customize via $ROFI_TARGET_DIR or $HYPR_CONF_TARGET_DIR/keybinds.conf."

--- a/scripts/config/waybar_config.sh
+++ b/scripts/config/waybar_config.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 TARGET_FILE="$WAYBAR_TARGET_DIR/config"
 WAYBAR_H=$WAYBAR_EXPECTED_HEIGHT
 SCRIPTS_P="$HYPR_SCRIPTS_TARGET_DIR"

--- a/scripts/config/waybar_style.sh
+++ b/scripts/config/waybar_style.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 TARGET_FILE="$WAYBAR_TARGET_DIR/style.css"
 echo "Generating $TARGET_FILE..."
 mkdir -p "$(dirname "$TARGET_FILE")"

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 CONFIG_TARGET_DIR="$HOME/.config"
 BACKUP_DIR_BASE="$HOME/config_backups_crimson_cascade"
@@ -43,7 +44,7 @@ copy_component() {
     if [ -d "$full_source_path" ]; then mkdir -p "$full_target_path"; cp -rT "$full_source_path/" "$full_target_path/"; else cp "$full_source_path" "$full_target_path"; fi
     if [ $? -eq 0 ]; then
         echo "$component_name_for_msg files copied to $full_target_path."
-        if [ "$component_name_for_msg" == "Hyprland" ] && [ -d "$full_target_path/scripts" ]; then chmod +x $full_target_path/scripts/*.sh 2>/dev/null; fi
+        if [ "$component_name_for_msg" == "Hyprland" ] && [ -d "$full_target_path/scripts" ]; then chmod +x $full_target_path/scripts/*.sh; fi
     else echo "ERROR: Failed to copy $component_name_for_msg from $full_source_path."; fi; echo ""
 }
 
@@ -64,7 +65,7 @@ TEMP_CLONE_DIR=""
 if [ -d ".git" ] && [ -d "$(git rev-parse --show-toplevel 2>/dev/null)/hypr" ]; then
     echo "Running from Git repository. Attempting to update..."
     DOTFILES_SOURCE_DIR="$(git rev-parse --show-toplevel)"
-    (cd "$DOTFILES_SOURCE_DIR" && git pull origin main) 
+    git -C "$DOTFILES_SOURCE_DIR" pull origin main
     if [ $? -ne 0 ]; then echo "ERROR: 'git pull' failed."; exit 1; fi
     echo "Repository updated from $DOTFILES_SOURCE_DIR."
 else


### PR DESCRIPTION
This commit introduces several improvements across the codebase without altering core functionality:

Shell Script Enhancements:
- Standardized all shell scripts to use `#!/usr/bin/env bash` for better portability.
- Implemented robust error handling by setting `set -euo pipefail` in all scripts.
- In `setup.sh`:
    - Changed `git pull` invocation to use `git -C` for clarity.
    - Removed error suppression from `chmod +x` command to ensure visibility of potential permission issues during setup.

Configuration File Improvements:
- In `hypr/hyprland.conf`:
    - Updated `source` directives to use relative paths (e.g., `conf/file.conf` instead of `~/.config/hypr/conf/file.conf`), aligning with Hyprland's recommended practices for portability.
- In `hypr/conf/decorations.conf`:
    - Reformatted the `blur` section for improved readability, with each option on a separate line.

These changes aim to make the dotfiles more robust, easier to maintain, and more aligned with common best practices.