### PR TITLE
Feat: Consolidate script enhancements and final fixes

### DIFF
--- a/scripts/setup_lib/backup.sh
+++ b/scripts/setup_lib/backup.sh
@@ -16,7 +16,8 @@ _do_backup_item() {
         if mv "$target_config_path" "$SPECIFIC_BACKUP_DIR/$BASENAME"; then
             echo "Backup of $BASENAME successful."
         else
-            echo "WARNING: Backup of $BASENAME failed."
+            echo "ERROR: Backup of $BASENAME to $SPECIFIC_BACKUP_DIR/$BASENAME failed." >&2
+            exit 1
         fi
     fi
 }

--- a/scripts/setup_lib/dependencies.sh
+++ b/scripts/setup_lib/dependencies.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 verify_core_dependencies() {
-    local essential_commands=("git" "brightnessctl" "notify-send")
+    local essential_commands=("brightnessctl" "git" "hyprctl" "hyprlock" "notify-send" "pactl" "rofi" "waybar" )
     local missing_commands=()
     local command_found_status=0
 

--- a/scripts/setup_lib/fs_ops.sh
+++ b/scripts/setup_lib/fs_ops.sh
@@ -31,22 +31,33 @@ copy_component() {
     fi
 
     echo "Processing $component_name_for_msg..."
-    mkdir -p "$target_dir"
-
-    if [ -d "$full_source_path" ]; then
-        mkdir -p "$full_target_path"
-        cp -rT "$full_source_path/" "$full_target_path/"
-    else
-        cp "$full_source_path" "$full_target_path"
+    if ! mkdir -p "$target_dir"; then
+        echo "ERROR: Failed to create target directory $target_dir for $component_name_for_msg." >&2
+        exit 1
     fi
 
-    if [ $? -eq 0 ]; then
-        echo "$component_name_for_msg files copied to $full_target_path."
-        if [ "$component_name_for_msg" == "Hyprland" ] && [ -d "$full_target_path/scripts" ]; then
-            chmod +x "$full_target_path/scripts/"*.sh
+    if [ -d "$full_source_path" ]; then
+        if ! mkdir -p "$full_target_path"; then
+             echo "ERROR: Failed to create target directory $full_target_path for $component_name_for_msg." >&2
+             exit 1
+        fi
+        if ! cp -rT "$full_source_path/" "$full_target_path/"; then
+            echo "ERROR: Failed to copy directory $component_name_for_msg from $full_source_path to $full_target_path." >&2
+            exit 1
         fi
     else
-        echo "ERROR: Failed to copy $component_name_for_msg from $full_source_path."
+        if ! cp "$full_source_path" "$full_target_path"; then
+            echo "ERROR: Failed to copy file $component_name_for_msg from $full_source_path to $full_target_path." >&2
+            exit 1
+        fi
+    fi
+
+    echo "$component_name_for_msg files copied to $full_target_path."
+    if [ "$component_name_for_msg" == "Hyprland" ] && [ -d "$full_target_path/scripts" ]; then
+        # Decide if this should be a fatal error - for now, a warning.
+        if ! chmod +x "$full_target_path/scripts/"*.sh; then
+            echo "WARNING: Failed to make Hyprland scripts executable in $full_target_path/scripts/." >&2
+        fi
     fi
     echo ""
 }
@@ -65,13 +76,15 @@ copy_single_file() {
 
     if [ -f "$full_source_path" ]; then
         echo "Copying $component_name_for_msg file..."
-        mkdir -p "$target_dir"
-        cp "$full_source_path" "$full_target_path"
-        if [ $? -eq 0 ]; then
-            echo "$component_name_for_msg file copied."
-        else
-            echo "ERROR: Failed to copy $component_name_for_msg file."
+        if ! mkdir -p "$target_dir"; then
+            echo "ERROR: Failed to create target directory $target_dir for $component_name_for_msg file." >&2
+            exit 1
         fi
+        if ! cp "$full_source_path" "$full_target_path"; then
+            echo "ERROR: Failed to copy $component_name_for_msg file from $full_source_path to $full_target_path." >&2
+            exit 1
+        fi
+        echo "$component_name_for_msg file copied."
     else
         echo "WARNING: Source '$full_source_path' not found. $component_name_for_msg config not copied."
     fi

--- a/scripts/setup_lib/git_ops.sh
+++ b/scripts/setup_lib/git_ops.sh
@@ -11,9 +11,9 @@ determine_source_dir() {
         current_branch=$(git -C "$local_dotfiles_source_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
 
         echo "Fetching updates from origin..." >&2
-        git -C "$local_dotfiles_source_dir" fetch origin >&2
-        if [ $? -ne 0 ]; then
-            echo "WARNING: 'git fetch origin' failed. Proceeding with caution." >&2
+        if ! git -C "$local_dotfiles_source_dir" fetch origin >&2; then
+            echo "ERROR: 'git fetch origin' failed. Cannot ensure repository is up to date." >&2
+            exit 1
         fi
 
         if [ "$current_branch" != "main" ]; then
@@ -38,9 +38,9 @@ determine_source_dir() {
         fi
 
         echo "Ensuring local 'main' branch tracks 'origin/main'..." >&2
-        git -C "$local_dotfiles_source_dir" branch --set-upstream-to=origin/main main >&2
-        if [ $? -ne 0 ]; then
-            echo "WARNING: Failed to set 'main' to track 'origin/main'. Pull might behave unexpectedly." >&2
+        if ! git -C "$local_dotfiles_source_dir" branch --set-upstream-to=origin/main main >&2; then
+            echo "ERROR: Failed to set 'main' to track 'origin/main'. Cannot ensure correct pull behavior." >&2
+            exit 1
         fi
 
         echo "Pulling changes for 'main' branch..." >&2

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This setup script installs dotfiles by copying pre-defined configuration files
+# directly from this repository into the appropriate ~/.config subdirectories.
+#
+# The scripts located in the scripts/config/ directory are primarily intended
+# for developer use. They serve as generators or templates to help create/update
+# the static configuration files stored within the repository (e.g., in hypr/, waybar/, alacritty/).
+# These generator scripts are NOT executed during the user-facing setup process
+# handled by this setup.sh script.
+
+
 CONFIG_TARGET_DIR="$HOME/.config"
 BACKUP_DIR_BASE="$HOME/config_backups_crimson_cascade"
 GIT_REPO_URL="https://github.com/vexalous/crimson-cascade-dots.git"
@@ -22,6 +32,7 @@ read -r DOTFILES_SOURCE_DIR TEMP_CLONE_DIR < <(determine_source_dir)
 if [ -n "$TEMP_CLONE_DIR" ]; then
     verify_core_dependencies
 fi
+
 
 declare -a components_to_backup=("hypr" "waybar" "alacritty" "rofi")
 handle_backup_process "${components_to_backup[@]}"


### PR DESCRIPTION
This commit includes a comprehensive set of improvements to the dotfiles setup scripts, building upon previous fixes and addressing feedback:

1.  **`dependencies.sh` Enhanced:**
    - The `essential_commands` array in `verify_core_dependencies` is updated to include the full list of required tools: `("brightnessctl" "git" "hyprctl" "hyprlock" "notify-send" "pactl" "rofi" "waybar")`.
    - The list is alphabetically sorted.

2.  **`setup.sh` Informational Comment Restored:**
    - The comment block explaining the repository's configuration strategy (static files vs. generator scripts) has been restored at the top of the file.
    - `setup.sh` correctly sources `dependencies.sh` and calls `verify_core_dependencies`.

3.  **Clarity Comments Restored:**
    - Selectively restored useful comments to `scripts/setup_lib/fs_ops.sh` and `hypr/scripts/volume_notify.sh` to aid in understanding non-obvious logic.
    - Adjusted comment indentation in `fs_ops.sh` for better readability.

4.  **Verified Functional Fixes:**
    - All previously implemented functional fixes remain in place: - `backup.sh`: Exits if `mv` fails during backup. - `fs_ops.sh`: Exits on `mkdir` or `cp` failures. - `volume_notify.sh`: Checks for `pactl` availability and handles parsing errors gracefully. - `git_ops.sh`: Exits on critical `git fetch` or `git branch --set-upstream-to` failures.

This set of changes aims to provide a more robust, user-friendly, and maintainable set of setup scripts.