### PR TITLE
Refactor notification scripts for improved maintainability

### DIFF
--- a/hypr/scripts/brightness_notify.sh
+++ b/hypr/scripts/brightness_notify.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(dirname "$0")/colors.sh"
 
-CRIMSON="#DC143C"
-LIGHT_GRAY="#cccccc"
-NEAR_BLACK="#0a0a0a"
 APP_NAME="Brightness"
 ICON_LOW="/usr/share/icons/Papirus-Dark/48x48/status/notification-display-brightness-low.svg"
 ICON_MEDIUM="/usr/share/icons/Papirus-Dark/48x48/status/notification-display-brightness-medium.svg"
@@ -31,23 +29,17 @@ get_brightness_icon() {
     fi
 }
 
-send_brightness_notification() {
-    local percentage="$1"
-    local icon_path="$2"
-    notify-send -h string:x-canonical-private-synchronous:bright_notif \
-                -h int:value:"$percentage" \
-                -u low \
-                -i "$icon_path" \
-                -a "$APP_NAME" \
-                "Brightness ${percentage}%" \
-                --hint="string:fgcolor:$LIGHT_GRAY,string:bgcolor:$NEAR_BLACK,string:hlcolor:$CRIMSON"
-}
-
 main() {
     local brightness_p icon
     brightness_p=$(get_brightness_percentage)
     icon=$(get_brightness_icon "$brightness_p")
-    send_brightness_notification "$brightness_p" "$icon"
+
+    "$(dirname "$0")/notify.sh" \
+        -t "Brightness" \
+        -m "${brightness_p}%" \
+        -i "$icon" \
+        -a "$APP_NAME" \
+        -p "$brightness_p"
 }
 
 main

--- a/hypr/scripts/colors.sh
+++ b/hypr/scripts/colors.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Color definitions
+CRIMSON="#DC143C"
+LIGHT_GRAY="#cccccc"
+NEAR_BLACK="#0a0a0a"
+
+# It's good practice for sourced files to end with a success code,
+# though not strictly necessary for variable definitions.
+exit 0

--- a/hypr/scripts/notify.sh
+++ b/hypr/scripts/notify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source the shared color definitions
+# shellcheck source=./colors.sh
+source "$(dirname "$0")/colors.sh"
+
+# Default values
+DEFAULT_APP_NAME="System Notification"
+DEFAULT_ICON="dialog-information"
+DEFAULT_TITLE="Notification"
+DEFAULT_TEXT=""
+DEFAULT_PROGRESS_VALUE=-1 # Use -1 or an empty string to indicate no progress bar
+
+usage() {
+    echo "Usage: $0 -t <title> -m <message> [-a <app_name>] [-i <icon_path>] [-p <progress_value>]"
+    echo "  -t : Title of the notification (required)"
+    echo "  -m : Message body of the notification (required)"
+    echo "  -a : Application name (optional, default: $DEFAULT_APP_NAME)"
+    echo "  -i : Icon path or name (optional, default: $DEFAULT_ICON)"
+    echo "  -p : Progress value (0-100) to display a progress bar (optional)"
+    exit 1
+}
+
+TITLE=""
+MESSAGE=""
+APP_NAME="$DEFAULT_APP_NAME"
+ICON_PATH="$DEFAULT_ICON"
+PROGRESS_VALUE="$DEFAULT_PROGRESS_VALUE"
+
+# Parse arguments
+while getopts ":t:m:a:i:p:h" opt; do
+    case $opt in
+        t) TITLE="$OPTARG" ;;
+        m) MESSAGE="$OPTARG" ;;
+        a) APP_NAME="$OPTARG" ;;
+        i) ICON_PATH="$OPTARG" ;;
+        p) PROGRESS_VALUE="$OPTARG" ;;
+        h) usage ;;
+        \?) echo "Invalid option: -$OPTARG" >&2; usage ;;
+        :) echo "Option -$OPTARG requires an argument." >&2; usage ;;
+    esac
+done
+
+if [ -z "$TITLE" ] || [ -z "$MESSAGE" ]; then
+    echo "Error: Title and message are required." >&2
+    usage
+fi
+
+# Construct notify-send command
+declare -a notify_args=()
+
+notify_args+=("-u" "low") # Urgency
+notify_args+=("-a" "$APP_NAME")
+notify_args+=("-i" "$ICON_PATH")
+notify_args+=("-h" "string:fgcolor:$LIGHT_GRAY")
+notify_args+=("-h" "string:bgcolor:$NEAR_BLACK")
+notify_args+=("-h" "string:hlcolor:$CRIMSON")
+notify_args+=("-h" "string:x-canonical-private-synchronous:generic_notif") # Allows replacing by ID
+
+if [[ "$PROGRESS_VALUE" -ge 0 && "$PROGRESS_VALUE" -le 100 ]]; then
+    notify_args+=("-h" "int:value:$PROGRESS_VALUE")
+fi
+
+notify_args+=("$TITLE")
+notify_args+=("$MESSAGE")
+
+notify-send "${notify_args[@]}"
+
+exit 0

--- a/hypr/scripts/volume_notify.sh
+++ b/hypr/scripts/volume_notify.sh
@@ -9,10 +9,8 @@ if ! command -v pactl &> /dev/null; then
     fi
     exit 1
 fi
+source "$(dirname "$0")/colors.sh"
 
-CRIMSON="#DC143C"
-LIGHT_GRAY="#cccccc"
-NEAR_BLACK="#0a0a0a"
 ICON_MUTED="/usr/share/icons/Papirus-Dark/48x48/panel/audio-volume-muted.svg"
 ICON_LOW="/usr/share/icons/Papirus-Dark/48x48/panel/audio-volume-low.svg"
 ICON_MEDIUM="/usr/share/icons/Papirus-Dark/48x48/panel/audio-volume-medium.svg"
@@ -43,21 +41,6 @@ is_source_muted() {
     pactl get-source-mute @DEFAULT_SOURCE@ | grep -q yes
 }
 
-send_notification() {
-    local notification_title="$1"
-    local percentage_value="$2"
-    local icon_path="$3"
-    local display_text="$4"
-
-    notify-send -h string:x-canonical-private-synchronous:vol_notif \
-                -h int:value:"$percentage_value" \
-                -u low \
-                -i "$icon_path" \
-                -a "$notification_title" \
-                "$display_text" \
-                --hint="string:fgcolor:$LIGHT_GRAY,string:bgcolor:$NEAR_BLACK,string:hlcolor:$CRIMSON"
-}
-
 process_mic_mute_status() {
     local notification_title="Microphone"
     local icon_path
@@ -73,7 +56,13 @@ process_mic_mute_status() {
         display_text="Mic On"
         percentage_value=100
     fi
-    send_notification "$notification_title" "$percentage_value" "$icon_path" "$display_text"
+
+    "$(dirname "$0")/notify.sh" \
+        -t "$notification_title" \
+        -m "$display_text" \
+        -i "$icon_path" \
+        -a "$notification_title" \
+        -p "$percentage_value"
 }
 
 process_volume_status() {
@@ -101,7 +90,13 @@ process_volume_status() {
         display_text="${current_volume}%"
         percentage_value="$current_volume"
     fi
-    send_notification "$notification_title" "$percentage_value" "$icon_path" "$display_text"
+
+    "$(dirname "$0")/notify.sh" \
+        -t "$notification_title" \
+        -m "$display_text" \
+        -i "$icon_path" \
+        -a "$notification_title" \
+        -p "$percentage_value"
 }
 
 main() {


### PR DESCRIPTION
This commit introduces a centralized approach to sending notifications and managing color schemes within the Hyprland scripts.

Key changes:
- Created `hypr/scripts/colors.sh` to store common color definitions, reducing redundancy and simplifying color scheme updates.
- Introduced a generic `hypr/scripts/notify.sh` script that handles the `notify-send` command with consistent styling and options, including progress bar support.
- Updated `hypr/scripts/brightness_notify.sh` and `hypr/scripts/volume_notify.sh` to:
    - Source `colors.sh` for color variables.
    - Utilize the new `notify.sh` for sending notifications, delegating the `notify-send` execution to the generic script.
    - Retain their specific logic for determining brightness/volume levels and appropriate icons.

These changes make the notification system more modular, easier to maintain, and simpler to customize in the future.